### PR TITLE
ci: sync deploy with upstream mickaelcanouilfr extension

### DIFF
--- a/.github/workflows/assets/_quarto.yml
+++ b/.github/workflows/assets/_quarto.yml
@@ -1,40 +1,16 @@
 project:
   type: website
+  render:
+    - index.qmd
   resources:
     - .nojekyll
     - CNAME
-format:
-  html:
-    logo:
-      light: logo-dark-path.svg
-      dark: logo-light-path.svg
-    logo-alt: "Mickaël CANOUIL logo"
-    theme:
-      light:
-        - cosmo
-        - brand
-        - theme.scss
-      dark:
-        - cosmo
-        - brand
-        - theme.scss
-    include-in-header:
-      - text: |
-          <style type="text/css">
-          .nav-footer {
-            border-top: unset;
-          }
-          </style>
-    include-after-body:
-      - text: |
-          <script>
-            document.getElementById('current-year').textContent = new Date().getFullYear();
-          </script>
+format: mickaelcanouilfr-html
 website:
   title: "GitHub Profile"
   description: "A landing page for Mickaël CANOUIL GitHub profile."
-  favicon: logo-light-path.svg
-  image: social-profile.png
+  favicon: _extensions/mickaelcanouilfr/assets/images/logo-gold-path.svg
+  image: assets/images/social-profile.png
   site-url: https://m.canouil.dev
   open-graph: true
   twitter-card: true
@@ -45,4 +21,4 @@ website:
     center: |
       &copy; []{#current-year} [Mickaël CANOUIL](https://mickael.canouil.fr){target="_blank" rel="noopener noreferrer"}. [{{< iconify octicon:heart-fill-16 title="Heart" label="Heart" >}} Sponsor](https://github.com/sponsors/mcanouil?o=esb){target="_blank" rel="noopener noreferrer"}.
     right: |
-      License: [CC BY NC SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0){target="_blank" rel="noopener noreferrer"}.
+      License: [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0){target="_blank" rel="noopener noreferrer"}.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,44 +35,29 @@ jobs:
       - name: Render Quarto Project
         shell: bash
         run: |
-          gh api \
-            -H "Accept: application/vnd.github.raw" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/mcanouil/mickael.canouil.fr/contents/index.qmd > index.qmd
+          git clone --no-checkout --depth 1 --filter=blob:none \
+            "https://x-access-token:${GH_TOKEN}@github.com/mcanouil/mickael.canouil.fr.git" upstream
+          git -C upstream sparse-checkout init --cone
+          git -C upstream sparse-checkout set \
+            assets/images \
+            _extensions/mickaelcanouilfr \
+            _extensions/mcanouil
+          git -C upstream checkout
 
-          gh api \
-            -H "Accept: application/vnd.github.raw" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/mcanouil/mickael.canouil.fr/contents/assets/images/social-profile.png > social-profile.png
+          cp upstream/index.qmd index.qmd
+          mkdir -p assets/images _extensions
+          cp upstream/assets/images/profile.png upstream/assets/images/social-profile.png assets/images/
+          cp -R upstream/_extensions/mickaelcanouilfr _extensions/
+          cp -R upstream/_extensions/mcanouil _extensions/
+          rm -rf upstream
 
-          gh api \
-            -H "Accept: application/vnd.github.raw" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/mcanouil/mickael.canouil.fr/contents/assets/images/logo-light-path.svg > logo-light-path.svg
-
-          gh api \
-            -H "Accept: application/vnd.github.raw" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/mcanouil/mickael.canouil.fr/contents/assets/images/profile.png > profile.png
-
-          gh api \
-            -H "Accept: application/vnd.github.raw" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/mcanouil/mickael.canouil.fr/contents/assets/stylesheets/theme.scss > theme.scss
-
-          sed -i 's|/assets/images/profile.png|profile.png|g' index.qmd
-          sed -i 's|/assets/images/social-profile.png|social-profile.png|g' index.qmd
-          sed -i 's|/assets/images/logo-light-path.svg|logo-light-path.svg|g' index.qmd
-          sed -i 's|links:|links:\n    - text: "{{< iconify octicon:home-fill-16 >}}"\n      href: "https://mickael.canouil.fr/"\n      target: "_blank"\n      rel: "noopener noreferrer"\n      aria-label: "home logo for personal website"|' index.qmd
-
-          quarto add mcanouil/quarto-iconify --no-prompt --quiet
-          quarto add mcanouil/quarto-mcanouil --no-prompt --quiet
+          sed -i 's|  links:|  links:\n    - text: "{{< iconify octicon:home-fill-16 >}}"\n      href: "https://mickael.canouil.fr/"\n      target: "_blank"\n      rel: "noopener noreferrer"\n      aria-label: "home logo for personal website"|' index.qmd
 
           touch .nojekyll
           echo "m.canouil.dev" > CNAME
           cp .github/workflows/assets/_quarto.yml _quarto.yml
 
-          quarto render index.qmd
+          quarto render
 
       - uses: actions/configure-pages@v5
 


### PR DESCRIPTION
## Context

Upstream `mickael.canouil.fr` moved styling into the `mickaelcanouilfr` Quarto extension, and `index.qmd` now requires the `mickaelcanouilfr-html` format. The old deploy fetched `theme.scss` and `logo-light-path.svg` from `assets/` paths that no longer exist (404), so the build was broken.

## Changes

- **deploy.yml**: replace per-file `gh api` fetches + path-rewrite seds + `quarto add` with a shallow, partial, sparse checkout of the upstream homepage sources (`index.qmd`, `assets/images`, `_extensions/mickaelcanouilfr`, `_extensions/mcanouil`). Render the whole project so `CNAME`/`.nojekyll` land in `_site`.
- **assets/_quarto.yml**: rewrite to a single-page `website` project using `format: mickaelcanouilfr-html` with an explicit `render: [index.qmd]`, no navbar, favicon from the vendored extension. Drop the dead cosmo/brand/`theme.scss` block, nav-footer border CSS, and current-year script (the extension's `current-year.lua` handles it).

## Verification

Local project render of the staged sources: `_site/index.html` builds, `mickaelcanouilfr-html` resolves, extension styling/logos applied, 21 iconify icons, no navbar/broken internal links, footer year resolves, home link to `mickael.canouil.fr`, profile image and avatar match upstream over a web root.